### PR TITLE
Added blurType Property to HUD

### DIFF
--- a/CCActivityHUD/CCActivityHUD.h
+++ b/CCActivityHUD/CCActivityHUD.h
@@ -99,6 +99,11 @@ typedef NS_ENUM(NSInteger, CCActivityHUDOverlayType) {
 @property CCActivityHUDOverlayType overlayType;
 
 /**
+ *  Set the type of the blur background view.
+ */
+@property UIBlurEffectStyle blurType;
+
+/**
  *  Set the progress of the task, when the task is completed, the value of progess is 1.
  */
 @property (nonatomic) CGFloat progress;

--- a/CCActivityHUD/CCActivityHUD.m
+++ b/CCActivityHUD/CCActivityHUD.m
@@ -290,6 +290,7 @@
         self.appearAnimationType = CCActivityHUDAppearAnimationTypeFadeIn;
         self.disappearAnimationType = CCActivityHUDDisappearAnimationTypeFadeOut;
         self.overlay = CCActivityHUDOverlayTypeNone;
+        self.blurType = UIBlurEffectStyleExtraLight;
         
         [self addNotificationObserver];
     }
@@ -466,7 +467,7 @@
 }
 
 - (void)addBlurOverlay {
-    UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleExtraLight];
+    UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:self.blurType];
     UIVisualEffectView *overlayView = [[UIVisualEffectView alloc] initWithFrame:BoundsFor(Screen)];
     overlayView.effect = blurEffect;
     self.overlay = overlayView;


### PR DESCRIPTION
Added a property `blurType` to allow the user to choose their blur type if they have a Blurred Overlay. Defaults to ExtraLight.